### PR TITLE
docs(readme): fix outdated docpad plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For more details, see `package.json` file.
 * [DocPad plugin "livereload"](https://github.com/docpad/docpad-plugin-livereload/), workspace live reload
 * [DocPad plugin "marked"](https://github.com/docpad/docpad-plugin-marked), MarkDown support
   * [Marked source](https://github.com/chjj/marked)
-* [DocPad plugin "nodesass"](https://github.com/jking90/docpad-plugin-nodesass), NodeJS SASS support
+* [DocPad plugin "nodesass"](https://github.com/docpad/docpad-plugin-nodesass), NodeJS SASS support
   * [node-sass](https://github.com/andrew/node-sass)
 * [DocPad plugin "partials"](https://github.com/docpad/docpad-plugin-partials), view partials
 


### PR DESCRIPTION
This plugin moved to the docpad org